### PR TITLE
Github ribbon

### DIFF
--- a/sass/base/_layout.scss
+++ b/sass/base/_layout.scss
@@ -161,6 +161,27 @@ body {
 	}
 }
 
+// Github Ribbon
+.github-ribbon {
+	margin-right: -15px;
+	margin-top:  -10px;
+	#post-index article & {
+		margin-top:  -25px;
+	}
+	@media #{$medium} {
+		margin-right: -30px;
+		margin-top:  -20px;
+		#post-index article & {
+			margin-top:  -30px;
+		}
+	}
+	@media #{$large} {
+		margin-right: -80px;
+		margin-top:  -50px;
+	}
+	float: right;
+}
+
 // Footer
 // --------------------------------------------------
 .footer-wrapper {

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -8,6 +8,9 @@ the index page or a normal post page.
 {% capture titlecased %}{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}{% endcapture %}
 
 <header>
+  {% if post.github_repo %}
+    <a href="{{ post.github_repo }}" target="_blank"><img class="github-ribbon" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
+  {% endif %}
   <div class="entry-meta">
     <span class="entry-date date published updated">
       <time datetime="{{ post.date | date_to_xmlschema }}">

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -30,6 +30,9 @@
       </div><!-- /.header-title-wrap -->
     </header>
     <div class="entry-content">
+      {% if page.github_repo %}
+	      <a href="{{ page.github_repo }}" target="_blank"><img class="github-ribbon" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
+      {% endif %}
       {{ content }}
       <footer class="entry-meta">
         <span class="entry-tags">{% for tag in page.categories %}<a href="{{ root_url }}/categories/#{{ tag | cgi_encode }}" title="Pages tagged {{ tag }}" class="tag">{{ tag }}</a>{% endfor %}</span>


### PR DESCRIPTION
I have added a `github_repo` to pages and posts where it expects a Github repository URL and adds a ribbon with a link.

Currently it's set to the green ribbon because it's what suits my style best and I honestly don't know how to do it without a whole bunch of `ifs` and `elses` for all possible ribbons. Suggestions are welcomed, but if there's no other way to do it, I'll add the code.

Obs, to enable custom ribbons, the user would have to configure it either in the `_config.yml` or per page.

[Github ribbons](https://github.com/blog/273-github-ribbons)